### PR TITLE
fixing gene symbol bug with gene lookup

### DIFF
--- a/PubTator/HGNCParser.py
+++ b/PubTator/HGNCParser.py
@@ -26,7 +26,7 @@ def load_genes():
         if cntr == 1:
             continue
         cols = line.split("\t")
-        genes_dict[cols[1]] = cols[18]
+        genes_dict[str(cols[1]).upper()] = cols[18]
 
     hgnc_file.close()
     return genes_dict

--- a/application.py
+++ b/application.py
@@ -109,8 +109,6 @@ def phenotypes():
     req_json = request.get_json()
     search_phenotypes_list = req_json['phenotypes']
     search_gene = req_json['gene']
-    if 'ORF' in str(search_gene):
-        search_gene = str(search_gene).replace('ORF', 'orf')
 
     phenotypes4gene = PhenotypeCorrelationParser \
         .read_pubmed_info_from_index("./HPO_graph_data/gene2phenotype.json",


### PR DESCRIPTION
This fixes the gene symbol lookup for the tables when a gene symbol has lower case `orf` in the symbol, like C12orf4.

- [x] pull the branch, build the application docker container, deploy locally
- [x] type in a few phenotypes to search and select `table`
- [x] search the results table for C12ORF4, click it and confirm that the sub tables with the rank break down and publication table appear