### PR TITLE
Server restart automatically on crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,19 @@
-version: '2'
+version: '3.4'
 
 services:
-    fixtures:
-        image: docker-registry.haib.org/sdi/layered-graph-fixtures
-    rest:
-        image: docker-registry.haib.org/sdi/layered-graph-server
-        volumes_from:
-          - fixtures
-        ports:
-            - "5000:5000"
+  fixtures:
+    image: docker-registry.haib.org/sdi/layered-graph-fixtures
+    volumes:
+      - fixtures-volume:/LayeredGraph/HPO_graph_data
+  rest:
+    image: docker-registry.haib.org/sdi/layered-graph-server
+    volumes:
+      - fixtures-volume:/LayeredGraph/HPO_graph_data
+    ports:
+      - "5000:5000"
+    restart: always
+    depends_on:
+      - fixtures
+
+volumes:
+  fixtures-volume:

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -1,13 +1,20 @@
-version: '2'
+version: '3.4'
 
 services:
-    fixtures:
-        image: docker-registry.haib.org/sdi/layered-graph-fixtures
-    rest:
-        image: docker-registry.haib.org/sdi/layered-graph-server
-        volumes_from:
-          - fixtures
-        volumes:
-          - ./:/LayeredGraph/
-        ports:
-            - "5000:5000"
+  fixtures:
+    image: docker-registry.haib.org/sdi/layered-graph-fixtures
+    volumes:
+      - fixtures-volume:/LayeredGraph/HPO_graph_data
+  rest:
+    image: docker-registry.haib.org/sdi/layered-graph-server
+    volumes:
+      - fixtures-volume:/LayeredGraph/HPO_graph_data
+      - ./:/LayeredGraph/
+    ports:
+      - "5000:5000"
+    restart: always
+    depends_on:
+      - fixtures
+
+volumes:
+  fixtures-volume:


### PR DESCRIPTION
These are only changes to the docker compose file to a) update to a newer version of compose to allow the automatic restart option, b) reworking of the way the fixtures volume is attached due to the updated compose syntax, and c) setting the policy for the rest server to restart automatically on failure.

To test this start up pyxismap issuing the `docker-compose up -d` command. Wait a minute and follow these steps to confirm that the restart policy is working:

1. do a `docker ps` and note the amount of time the rest container has been up and running for (in the status column)
2. get a terminal in the rest container `docker exec -it layeredgraph_rest_1 bash`
3. do a `ps -ef` and find the PID of the `/usr/local/bin/python3 application.py` process (should eb something like 11 or 12)
4. execute `kill -9 $PID` where $PID is the number for the process identified in step 3
5. after a second you should be booted from the terminal in the container and be back to your terminal
6. run `docker ps` again and now note the amount of time that the rest container has been running for. In the status column you should see that the container has only been up and running for a few seconds

This process shows that even though you killed the rest server docker compose detected this and restarted the container. 